### PR TITLE
Feat/tf 18 social login

### DIFF
--- a/app/(auth)/login/callback/page.tsx
+++ b/app/(auth)/login/callback/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/config/supabase";
+import { User } from "@supabase/supabase-js";
+import Loader from "@/app/loading";
+
+export default function AuthCallback() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleAuthCallback = async () => {
+      try {
+        // URL에서 인증 정보 가져오기
+        const { data, error } = await supabase.auth.getSession();
+
+        if (error) {
+          console.error("인증 에러:", error);
+          router.push("/login");
+          return;
+        }
+
+        if (data.session) {
+          console.log("로그인 성공:", data.session.user);
+          await saveUserToPrisma(data.session.user);
+          router.push("/");
+        } else {
+          router.push("/login");
+        }
+      } catch (error) {
+        console.error("콜백 처리 실패:", error);
+        router.push("/login");
+      }
+    };
+
+    handleAuthCallback();
+  }, [router]);
+
+  // Prisma로 사용자 정보 저장하는 함수
+  const saveUserToPrisma = async (user: User) => {
+    try {
+      const response = await fetch("/api/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        // TODO: 사용자 재료 적용 필요
+        body: JSON.stringify({
+          id: user.id,
+          name: user.user_metadata?.full_name || user.user_metadata?.name,
+          avatar: user.user_metadata?.avatar_url,
+          provider: user.app_metadata?.provider,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("사용자 저장 실패");
+      }
+    } catch (error) {
+      console.error("Prisma 저장 에러:", error);
+    }
+  };
+
+  return <Loader />;
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,7 +1,23 @@
+"use client";
+
 import { ChefHat, Refrigerator } from "lucide-react";
 import Image from "next/image";
+import { supabase } from "@/config/supabase";
 
 const Login = () => {
+  const handleOAuthLogin = async (provider: "kakao" | "google") => {
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+          redirectTo: `${window.location.origin}/login/callback`,
+        },
+      });
+      if (error) console.error(`${provider} 로그인 에러:`, error);
+    } catch (error) {
+      console.error(`${provider} 로그인 실패:`, error);
+    }
+  };
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-green-50 to-teal-100 flex items-center justify-center p-4 relative overflow-hidden">
       <div className="absolute top-10 left-10 w-32 h-32 bg-green-200/30 rounded-full blur-xl"></div>
@@ -74,7 +90,7 @@ const Login = () => {
         <div className="space-y-4 w-full">
           {/* 구글 로그인 */}
           <button
-            formAction="/auth/google"
+            onClick={() => handleOAuthLogin("google")}
             className="w-full flex items-center justify-center gap-3 bg-white border-2 border-gray-200 rounded-xl py-4 px-6 hover:border-gray-300 hover:shadow-md transition-all duration-200 group"
           >
             <Image
@@ -90,7 +106,7 @@ const Login = () => {
 
           {/* 카카오 로그인 */}
           <button
-            formAction="/auth/kakao"
+            onClick={() => handleOAuthLogin("kakao")}
             className="w-full flex items-center justify-center gap-3 bg-yellow-300 rounded-xl py-4 px-6 hover:bg-yellow-400 transition-all duration-200"
           >
             <Image

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { id, name, avatar, provider } = await request.json();
+
+    // 이미 존재하는 사용자인지 확인
+    const existingUser = await prisma.user.findUnique({
+      where: { id },
+    });
+
+    if (existingUser) {
+      // 이미 존재하는 사용자면 정보만 업데이트
+      const updatedUser = await prisma.user.update({
+        where: { id },
+        data: { name, avatar, lastLogin: new Date() },
+      });
+      return NextResponse.json(updatedUser, { status: 200 });
+    } else {
+      // 새 사용자 생성
+      const newUser = await prisma.user.create({
+        data: {
+          id,
+          name,
+          avatar,
+          provider,
+          createdAt: new Date(),
+          lastLogin: new Date(),
+        },
+      });
+      return NextResponse.json(newUser, { status: 201 });
+    }
+  } catch (error) {
+    console.error("데이터베이스 에러:", error);
+    return NextResponse.json(
+      {
+        message: "서버 에러",
+        error: error instanceof Error ? error.message : "알 수 없는 오류",
+      },
+      { status: 500 }
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/components/NavLoginButton.tsx
+++ b/components/NavLoginButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { User as UserIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { supabase } from "@/config/supabase";
+import type { User } from "@supabase/supabase-js";
+import Image from "next/image";
+
+const NavLoginButton = () => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    // 초기 세션 확인
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null);
+    });
+
+    // 로그인/로그아웃 상태 변화 감지
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+  };
+
+  if (user) {
+    return (
+      <button
+        onClick={handleLogout}
+        className="flex items-center gap-2 p-2 rounded-lg hover:bg-[#F3F4F6] transition-colors"
+      >
+        <Image
+          src={user.user_metadata.avatar_url}
+          alt="프로필 이미지"
+          width={24}
+          height={24}
+          className="w-6 h-6 md:w-6 md:h-6 rounded-full object-cover"
+        />
+        <span className="hidden md:inline text-sm text-[#374151]">
+          로그아웃
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      href="/login"
+      className="flex items-center gap-2 p-2 rounded-lg hover:bg-[#F3F4F6] transition-colors"
+    >
+      <UserIcon className="w-5 h-5 md:w-5 md:h-5 text-[#6B7280]" />
+      <span className="hidden md:inline text-sm text-[#374151]">로그인</span>
+    </Link>
+  );
+};
+
+export default NavLoginButton;

--- a/components/WebHeader.tsx
+++ b/components/WebHeader.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { User, Bell } from "lucide-react";
+import { Bell } from "lucide-react";
+import NavLoginButton from "./NavLoginButton";
 
 export default function WebHeader() {
   const pathname = usePathname();
@@ -69,13 +70,7 @@ export default function WebHeader() {
                 <Bell className="w-5 h-5 text-[#6B7280]" />
                 <span className="absolute -top-1 -right-1 w-3 h-3 bg-[#EF4444] rounded-full" />
               </button> */}
-              <Link
-                href="/login"
-                className="flex items-center gap-2 p-2 rounded-lg hover:bg-[#F3F4F6] transition-colors"
-              >
-                <User className="w-5 h-5 text-[#6B7280]" />
-                <span className="text-sm text-[#374151]">로그인</span>
-              </Link>
+              <NavLoginButton />
             </div>
           </div>
         </div>
@@ -95,20 +90,14 @@ export default function WebHeader() {
               <span className="absolute -top-1 -right-1 w-2 h-2 bg-[#EF4444] rounded-full" />
             </button> */}
 
-            {/* 모바일 로그인 버튼 */}
-            <Link
-              href="/login"
-              className="p-2 rounded-lg hover:bg-[#F3F4F6] transition-colors relative"
-            >
-              <User className="w-5 h-5 text-[#6B7280]" />
-            </Link>
+            <NavLoginButton />
           </div>
         </div>
       </header>
 
       {/* 모바일 하단 네비게이션 */}
       <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-[#E5E7EB] z-50 pb-[env(safe-area-inset-bottom)]">
-        <div className="grid grid-cols-2 px-2 py-1">
+        <div className="grid grid-cols-3 px-2 py-1">
           {nav.map((n) => (
             <Link
               key={n.href}

--- a/config/supabase.js
+++ b/config/supabase.js
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // 구글, 카카오 로그인 후 사용자 이미지 가져오기
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.googleusercontent.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@prisma/client": "6.15.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
+    "@supabase/supabase-js": "^2.57.4",
     "@tanstack/react-query": "^5.87.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.12)(react@19.1.0)
+      '@supabase/auth-helpers-nextjs':
+        specifier: ^0.10.0
+        version: 0.10.0(@supabase/supabase-js@2.57.4)
+      '@supabase/supabase-js':
+        specifier: ^2.57.4
+        version: 2.57.4
       '@tanstack/react-query':
         specifier: ^5.87.1
         version: 5.87.1(react@19.1.0)
@@ -586,6 +592,40 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@supabase/auth-helpers-nextjs@0.10.0':
+    resolution: {integrity: sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==}
+    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
+    peerDependencies:
+      '@supabase/supabase-js': ^2.39.8
+
+  '@supabase/auth-helpers-shared@0.7.0':
+    resolution: {integrity: sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==}
+    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
+    peerDependencies:
+      '@supabase/supabase-js': ^2.39.8
+
+  '@supabase/auth-js@2.71.1':
+    resolution: {integrity: sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==}
+
+  '@supabase/functions-js@2.4.6':
+    resolution: {integrity: sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==}
+
+  '@supabase/node-fetch@2.6.15':
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+
+  '@supabase/postgrest-js@1.21.4':
+    resolution: {integrity: sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==}
+
+  '@supabase/realtime-js@2.15.5':
+    resolution: {integrity: sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==}
+
+  '@supabase/storage-js@2.12.1':
+    resolution: {integrity: sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==}
+
+  '@supabase/supabase-js@2.57.4':
+    resolution: {integrity: sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -709,6 +749,9 @@ packages:
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
@@ -716,6 +759,9 @@ packages:
 
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.41.0':
     resolution: {integrity: sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==}
@@ -1586,6 +1632,9 @@ packages:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2036,6 +2085,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2167,6 +2219,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -2240,6 +2295,12 @@ packages:
       '@types/react':
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2264,6 +2325,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -2712,6 +2785,59 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@supabase/auth-helpers-nextjs@0.10.0(@supabase/supabase-js@2.57.4)':
+    dependencies:
+      '@supabase/auth-helpers-shared': 0.7.0(@supabase/supabase-js@2.57.4)
+      '@supabase/supabase-js': 2.57.4
+      set-cookie-parser: 2.7.1
+
+  '@supabase/auth-helpers-shared@0.7.0(@supabase/supabase-js@2.57.4)':
+    dependencies:
+      '@supabase/supabase-js': 2.57.4
+      jose: 4.15.9
+
+  '@supabase/auth-js@2.71.1':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/functions-js@2.4.6':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/node-fetch@2.6.15':
+    dependencies:
+      whatwg-url: 5.0.0
+
+  '@supabase/postgrest-js@1.21.4':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/realtime-js@2.15.5':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.12.1':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/supabase-js@2.57.4':
+    dependencies:
+      '@supabase/auth-js': 2.71.1
+      '@supabase/functions-js': 2.4.6
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.21.4
+      '@supabase/realtime-js': 2.15.5
+      '@supabase/storage-js': 2.12.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2818,6 +2944,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/react-dom@19.1.9(@types/react@19.1.12)':
     dependencies:
       '@types/react': 19.1.12
@@ -2825,6 +2953,10 @@ snapshots:
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.1.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.11
 
   '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -3878,6 +4010,8 @@ snapshots:
 
   jiti@2.5.1: {}
 
+  jose@4.15.9: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4301,6 +4435,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  set-cookie-parser@2.7.1: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -4492,6 +4628,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
@@ -4598,6 +4736,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4644,6 +4789,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  ws@8.18.3: {}
 
   yallist@5.0.0: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,3 +57,13 @@ model Ingredient {
   createdAt   DateTime            @default(now())
   updatedAt   DateTime            @updatedAt
 }
+
+// TODO: 사용자 재료 적용 필요
+model User {
+  id        String   @id @default(uuid())
+  name      String?
+  avatar    String?
+  provider  String?  // 'google', 'kakao' 등
+  createdAt DateTime @default(now())
+  lastLogin DateTime @default(now())
+}


### PR DESCRIPTION
## Jira Ticket Number
TF-18

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] 기능 개발

## 요약
- Supabase의 OAuth 기능을 활용하여 구글, 카카오 소셜 로그인 구현

## 상세 내용
- Supabase Auth Helpers 및 관련 라이브러리 추가
- 소셜 로그인 후 사용자 정보를 저장하기 위해 Prisma `User` 모델 추가
- 로그인 페이지에서 Supabase의 `signInWithOAuth`를 호출하도록 로직 변경
- OAuth 인증 후 리디렉션될 `/login/callback` 경로와 로직 추가
- 로그인 시 사용자 정보를 조회하거나 생성하는 API (`/api/users`) 구현
- 로그인 상태에 따라 사용자 프로필 이미지 또는 로그인 버튼을 표시하는 `NavLoginButton` 컴포넌트를 추가하고 헤더 적용
- `next.config.ts`에 구글, 카카오 프로필 이미지의 외부 도메인 추가

|데스크탑|모바일|
|:--:|:--:|
|<img width="951" height="62" alt="image" src="https://github.com/user-attachments/assets/837905f1-04d6-4a5b-abe8-da52e198abdd" />|<img width="478" height="54" alt="image" src="https://github.com/user-attachments/assets/dac2b702-143b-40f7-836e-f7284617db80" />|
