### PR TITLE
[TF-73]내 기록 페이지 데이터베이스 연동

### DIFF
--- a/app/api/cooking-records/route.ts
+++ b/app/api/cooking-records/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { createClient } from "@/lib/supabase/server";
+
+// 요리 기록 생성
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json(
+        { error: "로그인이 필요합니다." },
+        { status: 401 }
+      );
+    }
+
+    const userId = user.id;
+    const body = await request.json();
+    
+    const { recipeId, recipeName, usedIngredients, imageUrl } = body;
+
+    if (!recipeId || !recipeName || !usedIngredients || !Array.isArray(usedIngredients)) {
+      return NextResponse.json(
+        { error: "필수 데이터가 누락되었습니다." },
+        { status: 400 }
+      );
+    }
+
+    // 요리 기록 생성
+    const cookingRecord = await prisma.cookingRecord.create({
+      data: {
+        userId,
+        recipeId,
+        recipeName,
+        imageUrl: imageUrl || null,
+        usedIngredients: JSON.stringify(usedIngredients),
+        completedAt: new Date(),
+      },
+    });
+
+    return NextResponse.json(cookingRecord, { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/cooking-records] 오류:", error);
+    return NextResponse.json(
+      { error: "요리 기록 생성에 실패했습니다." },
+      { status: 500 }
+    );
+  }
+}
+
+// 요리 기록 조회
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json(
+        { error: "로그인이 필요합니다." },
+        { status: 401 }
+      );
+    }
+
+    const userId = user.id;
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get("limit") || "10");
+
+    // 최근 요리 기록 조회
+    const recentRecords = await prisma.cookingRecord.findMany({
+      where: { userId },
+      orderBy: { completedAt: "desc" },
+      take: limit,
+    });
+
+    // 자주 사용한 재료 통계 (최근 30일)
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const ingredientStats = await prisma.cookingRecord.findMany({
+      where: {
+        userId,
+        completedAt: {
+          gte: thirtyDaysAgo,
+        },
+      },
+      select: {
+        usedIngredients: true,
+      },
+    });
+
+    // 재료 사용 빈도 계산
+    const ingredientCount: Record<string, number> = {};
+    
+    ingredientStats.forEach((record) => {
+      try {
+        const ingredients = JSON.parse(record.usedIngredients as string) as Array<{
+          name: string;
+          quantity: number;
+        }>;
+        
+        ingredients.forEach((ingredient) => {
+          if (ingredient.name) {
+            ingredientCount[ingredient.name] = (ingredientCount[ingredient.name] || 0) + ingredient.quantity;
+          }
+        });
+      } catch (error) {
+        console.error("재료 데이터 파싱 실패:", error);
+      }
+    });
+
+    // 자주 사용한 재료 상위 10개
+    const frequentIngredients = Object.entries(ingredientCount)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([name, count]) => ({ name, count }));
+
+    // 레시피별 요리 횟수 통계
+    const recipeStats = await prisma.cookingRecord.groupBy({
+      by: ["recipeId", "recipeName"],
+      where: { userId },
+      _count: {
+        id: true,
+      },
+      orderBy: {
+        _count: {
+          id: "desc",
+        },
+      },
+      take: 10,
+    });
+
+    // 이번 달 통계
+    const thisMonth = new Date();
+    thisMonth.setDate(1);
+    thisMonth.setHours(0, 0, 0, 0);
+
+    const monthlyStats = await prisma.cookingRecord.aggregate({
+      where: {
+        userId,
+        completedAt: {
+          gte: thisMonth,
+        },
+      },
+      _count: {
+        id: true,
+      },
+    });
+
+    return NextResponse.json({
+      recentRecords: recentRecords.map(record => ({
+        ...record,
+        usedIngredients: JSON.parse(record.usedIngredients as string),
+      })),
+      frequentIngredients,
+      favoriteRecipes: recipeStats.map(stat => ({
+        recipeId: stat.recipeId,
+        recipeName: stat.recipeName,
+        cookingCount: stat._count.id,
+      })),
+      monthlyStats: {
+        cookingCount: monthlyStats._count.id || 0,
+      },
+    });
+  } catch (error) {
+    console.error("[GET /api/cooking-records] 오류:", error);
+    return NextResponse.json(
+      { error: "요리 기록 조회에 실패했습니다." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/recipes/[id]/RecipeDetailClient.tsx
+++ b/app/recipes/[id]/RecipeDetailClient.tsx
@@ -242,6 +242,8 @@ export default function RecipeDetailClient({ recipeId }: { recipeId: string }) {
             recipeIngredients={recipe.ingredients}
             userIngredientList={userIngredientList}
             onIngredientsUpdate={handleIngredientConfirm}
+            recipeId={recipe.id} 
+            recipeImageUrl={recipe.imageUrl} 
           />
         )}
       </div>

--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   TrendingUp,
   Clock,
@@ -8,111 +10,69 @@ import {
   Target,
   Sparkles,
 } from "lucide-react";
+import { useCookingRecords } from "@/hooks/useCookingRecordsQuery";
+import { Suspense } from "react";
+import Loader from "@/app/loading";
 
-export default function MyRecords() {
-  // 샘플 데이터
-  const monthlyStats = {
-    cookingCount: 12,
-    favoriteRecipe: "계란볶음밥",
-    mostUsedIngredient: "계란",
-    averageCookingTime: 18,
-  };
-
-  const recentCookings = [
-    {
-      id: "1",
-      name: "당근볶음",
-      date: "2025-08-29",
-      rating: 4,
-      imageUrl:
-        "https://images.unsplash.com/photo-1482049016688-2d3e1b311543?w=300&h=200&fit=crop",
-      cookingTime: 15,
-      difficulty: 2,
-    },
-    {
-      id: "2",
-      name: "계란볶음밥",
-      date: "2025-08-28",
-      rating: 5,
-      imageUrl:
-        "https://images.unsplash.com/photo-1603133872878-684f208fb84b?w=300&h=200&fit=crop",
-      cookingTime: 20,
-      difficulty: 3,
-    },
-    {
-      id: "3",
-      name: "우유빵",
-      date: "2025-08-27",
-      rating: 3,
-      imageUrl:
-        "https://images.unsplash.com/photo-1549931319-a545dcf3bc73?w=300&h=200&fit=crop",
-      cookingTime: 45,
-      difficulty: 4,
-    },
-  ];
-
-  const favoriteRecipes = [
-    {
-      id: "1",
-      name: "계란볶음밥",
-      cookingCount: 5,
-      imageUrl:
-        "https://images.unsplash.com/photo-1603133872878-684f208fb84b?w=300&h=200&fit=crop",
-      averageRating: 4.8,
-    },
-    {
-      id: "2",
-      name: "김치찌개",
-      cookingCount: 3,
-      imageUrl:
-        "https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=300&h=200&fit=crop",
-      averageRating: 4.3,
-    },
-    {
-      id: "3",
-      name: "당근볶음",
-      cookingCount: 2,
-      imageUrl:
-        "https://images.unsplash.com/photo-1482049016688-2d3e1b311543?w=300&h=200&fit=crop",
-      averageRating: 4.0,
-    },
-  ];
-
-  const achievements = [
-    {
-      id: "1",
-      title: "요리 달인",
-      description: "이번 달 10회 이상 요리 성공",
-      icon: "🏆",
-      earned: true,
-      earnedDate: "2025-08-25",
-    },
-    {
-      id: "2",
-      title: "건강 요리사",
-      description: "야채 요리 5회 이상 완성",
-      icon: "🥬",
-      earned: true,
-      earnedDate: "2025-08-20",
-    },
-    {
-      id: "3",
-      title: "시간 관리 마스터",
-      description: "30분 이내 요리 3회 완성",
-      icon: "⏰",
-      earned: false,
-      earnedDate: null,
-    },
-  ];
+function RecordsContent() {
+  const { data } = useCookingRecords(10);
+  const { recentRecords, frequentIngredients, favoriteRecipes, monthlyStats } =
+    data;
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return `${date.getMonth() + 1}월 ${date.getDate()}일`;
   };
 
-  const renderStars = (rating: number) => {
-    return "★".repeat(rating) + "☆".repeat(5 - rating);
+  const getTopIngredient = () => {
+    return frequentIngredients.length > 0
+      ? frequentIngredients[0].name
+      : "없음";
   };
+
+  const getFavoriteRecipe = () => {
+    return favoriteRecipes.length > 0 ? favoriteRecipes[0].recipeName : "없음";
+  };
+
+  // 중복 레시피 제거한 최근 요리 기록
+  const uniqueRecentRecords = recentRecords.reduce((unique, record) => {
+    if (!unique.some((item) => item.recipeId === record.recipeId)) {
+      unique.push(record);
+    }
+    return unique;
+  }, [] as typeof recentRecords);
+
+  // TODO:성취도 뱃지
+  const achievements = [
+    {
+      id: "1",
+      title: "요리 달인",
+      description: "이번 달 10회 이상 요리 성공",
+      icon: "🏆",
+      earned: monthlyStats.cookingCount >= 10,
+      earnedDate:
+        monthlyStats.cookingCount >= 10 ? new Date().toISOString() : null,
+    },
+    {
+      id: "2",
+      title: "건강 요리사",
+      description: "야채 재료 5회 이상 사용",
+      icon: "🥬",
+      earned: frequentIngredients.some(
+        (ing) =>
+          ["양파", "당근", "대파", "마늘"].includes(ing.name) && ing.count >= 5
+      ),
+      earnedDate: null,
+    },
+    {
+      id: "3",
+      title: "시간 관리 마스터",
+      description: "30분 이내 요리 3회 완성",
+      icon: "⏰",
+      earned: false, // 실제 구현시 요리 시간 데이터 필요
+      earnedDate: null,
+    },
+  ];
 
   return (
     <div className="min-h-screen bg-[#F9FAFB]">
@@ -125,7 +85,7 @@ export default function MyRecords() {
             </div>
             <div>
               <h1 className="text-2xl lg:text-3xl font-bold text-[#374151]">
-                내 요리 기록 📊
+                내 요리 기록
               </h1>
               <p className="text-[#6B7280]">
                 요리 여정을 한눈에 확인하고 성취를 기록하세요
@@ -140,7 +100,7 @@ export default function MyRecords() {
             <Calendar className="w-5 h-5 text-[#10B981]" />
             이번 달 통계
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB] hover:shadow-md transition-shadow duration-200">
               <div className="flex items-center gap-4">
                 <div className="p-3 bg-[#10B981]/10 rounded-xl">
@@ -165,7 +125,7 @@ export default function MyRecords() {
                     가장 많이 만든 요리
                   </div>
                   <div className="text-sm text-[#6B7280]">
-                    {monthlyStats.favoriteRecipe}
+                    {getFavoriteRecipe()}
                   </div>
                 </div>
               </div>
@@ -174,36 +134,22 @@ export default function MyRecords() {
             <div className="bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB] hover:shadow-md transition-shadow duration-200">
               <div className="flex items-center gap-4">
                 <div className="p-3 bg-[#F59E0B]/10 rounded-xl">
-                  <div className="text-2xl">🥚</div>
+                  <div className="text-2xl">🥕</div>
                 </div>
                 <div>
                   <div className="text-lg font-bold text-[#374151]">
                     가장 많이 사용한 재료
                   </div>
                   <div className="text-sm text-[#6B7280]">
-                    {monthlyStats.mostUsedIngredient}
+                    {getTopIngredient()}
                   </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB] hover:shadow-md transition-shadow duration-200">
-              <div className="flex items-center gap-4">
-                <div className="p-3 bg-[#8B5CF6]/10 rounded-xl">
-                  <Clock className="w-6 h-6 text-[#8B5CF6]" />
-                </div>
-                <div>
-                  <div className="text-2xl font-bold text-[#374151]">
-                    평균 {monthlyStats.averageCookingTime}분
-                  </div>
-                  <div className="text-sm text-[#6B7280]">요리 시간</div>
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        {/* 메인 콘텐츠 - 데스크톱: 2열, 모바일: 1열 */}
+        {/* 메인 콘텐츠 */}
         <div className="lg:grid lg:grid-cols-3 lg:gap-8 space-y-8 lg:space-y-0">
           {/* 왼쪽 컬럼 - 최근 요리 & 즐겨찾기 */}
           <div className="lg:col-span-2 space-y-8">
@@ -214,44 +160,54 @@ export default function MyRecords() {
                 최근 만든 요리
               </h3>
               <div className="space-y-4">
-                {recentCookings.map((cooking) => (
-                  <div
-                    key={cooking.id}
-                    className="flex gap-4 p-4 bg-[#F9FAFB] rounded-xl hover:bg-[#F3F4F6] transition-colors duration-200"
-                  >
-                    <div className="w-20 h-20 rounded-xl bg-gray-100 flex-shrink-0 overflow-hidden">
-                      <img
-                        src={cooking.imageUrl}
-                        alt={cooking.name}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between mb-2">
-                        <h4 className="font-semibold text-[#374151]">
-                          {cooking.name}
-                        </h4>
-                        <span className="text-sm text-[#6B7280] bg-white px-2 py-1 rounded-md">
-                          {formatDate(cooking.date)}
-                        </span>
+                {uniqueRecentRecords.length > 0 ? (
+                  uniqueRecentRecords.map((record) => (
+                    <div
+                      key={record.id}
+                      className="flex gap-4 p-4 bg-[#F9FAFB] rounded-xl hover:bg-[#F3F4F6] transition-colors duration-200"
+                    >
+                      <div className="w-20 h-20 rounded-xl bg-gray-100 flex-shrink-0 overflow-hidden">
+                        <img
+                          src={record.imageUrl || "/default-recipe.jpg"}
+                          alt={record.recipeName}
+                          className="w-full h-full object-cover"
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).src =
+                              "/default-recipe.jpg";
+                          }}
+                        />
                       </div>
-                      <div className="flex items-center gap-4 mb-2">
-                        <span className="text-[#F59E0B] text-sm">
-                          {renderStars(cooking.rating)}
-                        </span>
-                        <span className="text-xs text-[#6B7280]">
-                          ⏱️ {cooking.cookingTime}분
-                        </span>
-                        <span className="text-xs text-[#6B7280]">
-                          {"★".repeat(cooking.difficulty)} 난이도
-                        </span>
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between mb-2">
+                          <h4 className="font-semibold text-[#374151]">
+                            {record.recipeName}
+                          </h4>
+                          <span className="text-sm text-[#6B7280] bg-white px-2 py-1 rounded-md">
+                            {formatDate(record.completedAt)}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-4 mb-2">
+                          <span className="text-xs text-[#6B7280]">
+                            사용 재료:{" "}
+                            {record.usedIngredients
+                              .map((ing) => ing.name)
+                              .join(", ")}
+                          </span>
+                        </div>
                       </div>
                     </div>
+                  ))
+                ) : (
+                  <div className="text-center py-8 text-[#6B7280]">
+                    <div className="text-4xl mb-2">🍳</div>
+                    <p>아직 완성한 요리가 없어요!</p>
+                    <p className="text-sm">첫 번째 요리를 완성해보세요.</p>
                   </div>
-                ))}
+                )}
               </div>
             </div>
 
+            {/* TODO: 실제 즐겨찾기 기능 추가 */}
             {/* 즐겨찾기 레시피 */}
             <div className="bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB]">
               <h3 className="text-lg font-bold text-[#374151] mb-6 flex items-center gap-2">
@@ -259,42 +215,68 @@ export default function MyRecords() {
                 즐겨찾기 레시피
               </h3>
               <div className="space-y-4">
-                {favoriteRecipes.map((recipe) => (
-                  <div
-                    key={recipe.id}
-                    className="flex gap-4 p-4 bg-[#F9FAFB] rounded-xl hover:bg-[#F3F4F6] transition-colors duration-200"
-                  >
-                    <div className="w-20 h-20 rounded-xl bg-gray-100 flex-shrink-0 overflow-hidden">
-                      <img
-                        src={recipe.imageUrl}
-                        alt={recipe.name}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                    <div className="flex-1 flex items-center justify-between">
-                      <div>
-                        <h4 className="font-semibold text-[#374151] mb-1">
-                          {recipe.name}
+                {favoriteRecipes.length > 0 ? (
+                  favoriteRecipes.slice(0, 5).map((recipe) => (
+                    <div
+                      key={recipe.recipeId}
+                      className="flex items-center justify-between p-3 bg-[#F9FAFB] rounded-xl"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <h4 className="font-semibold text-[#374151] mb-1 truncate">
+                          {recipe.recipeName}
                         </h4>
-                        <div className="flex items-center gap-3">
-                          <span className="text-sm text-[#6B7280]">
-                            🍳 {recipe.cookingCount}번 요리
-                          </span>
-                          <span className="text-sm text-[#F59E0B]">
-                            ⭐ {recipe.averageRating}
-                          </span>
+                        <div className="text-sm text-[#6B7280]">
+                          🍳 {recipe.cookingCount}번 요리
                         </div>
                       </div>
-                      <Heart className="w-5 h-5 text-[#EF4444] fill-current" />
+                      <Heart className="w-5 h-5 text-[#EF4444] fill-current flex-shrink-0 ml-2" />
                     </div>
+                  ))
+                ) : (
+                  <div className="text-center py-6 text-[#6B7280]">
+                    <p>즐겨찾는 레시피가 없어요</p>
                   </div>
-                ))}
+                )}
               </div>
             </div>
           </div>
 
           {/* 오른쪽 컬럼 - 성취도 & 뱃지 */}
           <div className="lg:col-span-1 space-y-6">
+            {/* 자주 사용한 재료 */}
+            <div className="bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB]">
+              <h3 className="text-lg font-bold text-[#374151] mb-6 flex items-center gap-2">
+                <div className="text-xl">🥕</div>
+                자주 사용한 재료
+              </h3>
+              <div className="space-y-3">
+                {frequentIngredients.length > 0 ? (
+                  frequentIngredients.slice(0, 5).map((ingredient, index) => (
+                    <div
+                      key={ingredient.name}
+                      className="flex items-center justify-between p-3 bg-[#F9FAFB] rounded-xl"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 bg-[#10B981] text-white rounded-full flex items-center justify-center text-sm font-bold">
+                          {index + 1}
+                        </div>
+                        <span className="font-medium text-[#374151]">
+                          {ingredient.name}
+                        </span>
+                      </div>
+                      <span className="text-sm text-[#6B7280] bg-white px-3 py-1 rounded-full">
+                        {ingredient.count}회 사용
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-center py-6 text-[#6B7280]">
+                    <p>재료 사용 기록이 없어요</p>
+                  </div>
+                )}
+              </div>
+            </div>
+
             {/* 성취도 뱃지 */}
             <div className="bg-white rounded-2xl p-6 shadow-sm border border-[#E5E7EB]">
               <h3 className="text-lg font-bold text-[#374151] mb-6 flex items-center gap-2">
@@ -359,13 +341,27 @@ export default function MyRecords() {
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-sm">새로운 요리 도전</span>
-                  <span className="text-sm font-bold">2/3</span>
+                  <span className="text-sm font-bold">
+                    {Math.min(uniqueRecentRecords.length, 3)}/3
+                  </span>
                 </div>
                 <div className="w-full bg-white/20 rounded-full h-2">
-                  <div className="bg-[#F59E0B] h-2 rounded-full w-2/3"></div>
+                  <div
+                    className="bg-[#F59E0B] h-2 rounded-full transition-all duration-300"
+                    style={{
+                      width: `${Math.min(
+                        (uniqueRecentRecords.length / 3) * 100,
+                        100
+                      )}%`,
+                    }}
+                  ></div>
                 </div>
                 <p className="text-xs text-white/90">
-                  새로운 레시피 1개만 더 도전하면 목표 달성! 💪
+                  {uniqueRecentRecords.length >= 3
+                    ? "목표 달성! 🎉 새로운 도전을 계속해보세요!"
+                    : `새로운 레시피 ${
+                        3 - uniqueRecentRecords.length
+                      }개만 더 도전하면 목표 달성! 💪`}
                 </p>
               </div>
             </div>
@@ -385,5 +381,13 @@ export default function MyRecords() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function MyRecords() {
+  return (
+    <Suspense fallback={<Loader />}>
+      <RecordsContent />
+    </Suspense>
   );
 }

--- a/components/CookingCompleteModal.tsx
+++ b/components/CookingCompleteModal.tsx
@@ -15,6 +15,7 @@ import {
   normalizeIngredientForDisplay,
   processIngredientUpdates,
 } from "@/lib/recipeTransform";
+import { useCreateCookingRecord } from "@/hooks/useCookingRecordsQuery";
 
 interface CookingCompleteModalProps {
   isOpen: boolean;
@@ -23,6 +24,8 @@ interface CookingCompleteModalProps {
   userIngredientList: IngredientForRecipe[];
   recipeIngredients: RecipeIngredient[];
   onIngredientsUpdate: (updatedIngredients: RecipeIngredient[]) => void;
+  recipeId: number;
+  recipeImageUrl?: string;
 }
 
 export function CookingCompleteModal({
@@ -32,7 +35,10 @@ export function CookingCompleteModal({
   userIngredientList,
   recipeIngredients,
   onIngredientsUpdate,
+  recipeId,
+  recipeImageUrl,
 }: CookingCompleteModalProps) {
+  const createCookingRecord = useCreateCookingRecord();
   const normalizedRecipeIngredients = useMemo(() => {
     return recipeIngredients.map(normalizeIngredientForDisplay);
   }, [recipeIngredients]);
@@ -71,6 +77,13 @@ export function CookingCompleteModal({
       userIngredientList,
       usedIngredients
     );
+    // 요리 기록 저장
+    createCookingRecord.mutate({
+      recipeId,
+      recipeName: dishName,
+      usedIngredients,
+      imageUrl: recipeImageUrl,
+    });
 
     onIngredientsUpdate(updatedFridgeIngredients);
     onClose();

--- a/hooks/useCookingRecordsQuery.ts
+++ b/hooks/useCookingRecordsQuery.ts
@@ -1,0 +1,77 @@
+// hooks/useCookingRecordsQuery.ts
+import {
+  useSuspenseQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  getCookingRecords,
+  createCookingRecord,
+  getIngredientUsageHistory,
+  getRecipeCookingHistory,
+  type CookingRecordsResponse,
+  type UsedIngredient,
+} from "@/services/cookingRecords";
+
+// 쿼리 키 상수
+export const COOKING_RECORDS_QUERY_KEY = ["cookingRecords"];
+export const ingredientUsageQueryKey = (ingredientName: string) => [
+  "ingredientUsage",
+  ingredientName,
+];
+export const recipeCookingHistoryQueryKey = (recipeId: number) => [
+  "recipeCookingHistory",
+  recipeId,
+];
+
+// 요리 기록 전체 조회 (통계 포함) - 항상 실행되는 쿼리
+export const useCookingRecords = (limit?: number) => {
+  return useSuspenseQuery<CookingRecordsResponse>({
+    queryKey: [...COOKING_RECORDS_QUERY_KEY, { limit }],
+    queryFn: () => getCookingRecords(limit),
+    staleTime: 1000 * 60 * 5, // 5분간 fresh
+    retry: 2, // 실패시 2번 재시도
+  });
+};
+
+// 요리 기록 생성 mutation
+export const useCreateCookingRecord = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createCookingRecord,
+    onSuccess: (newRecord) => {
+      // 모든 요리 기록 관련 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: COOKING_RECORDS_QUERY_KEY });
+
+      console.log("요리 기록이 성공적으로 저장되었습니다:", newRecord);
+    },
+    onError: (error) => {
+      console.error("요리 기록 생성 실패:", error);
+    },
+  });
+};
+
+// 이번 달 요리 통계만 조회
+export const useMonthlyStats = () => {
+  const { data } = useCookingRecords();
+  return data.monthlyStats;
+};
+
+// 자주 사용한 재료 5개 조회
+export const useFrequentIngredients = (limit: number = 5) => {
+  const { data } = useCookingRecords();
+  return data.frequentIngredients.slice(0, limit);
+};
+
+// 즐겨찾기 레시피 상위 조회 (지금은 자주 완성한 레시피보여줌)
+export const useFavoriteRecipes = (limit: number = 5) => {
+  const { data } = useCookingRecords();
+  return data.favoriteRecipes.slice(0, limit);
+};
+
+// 최근 요리 기록 조회
+export const useRecentCookings = (limit: number = 10) => {
+  const { data } = useCookingRecords(limit);
+  return data.recentRecords;
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,4 +70,22 @@ model User {
   lastLogin DateTime @default(now())
 
   ingredients Ingredient[]
+   cookingRecords CookingRecord[]
+
+
 }
+model CookingRecord {
+  id              Int      @id @default(autoincrement())
+  userId          String
+  recipeId        Int
+  recipeName      String
+  imageUrl        String?
+  usedIngredients String   // JSON string으로 저장
+  completedAt     DateTime @default(now())
+  createdAt       DateTime @default(now())
+
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("cooking_records")
+}
+

--- a/services/cookingRecords.ts
+++ b/services/cookingRecords.ts
@@ -1,0 +1,104 @@
+// services/cookingRecords.ts
+
+export interface UsedIngredient {
+  name: string;
+  quantity: number;
+}
+
+export interface CookingRecord {
+  id: number;
+  userId: string;
+  recipeId: number;
+  recipeName: string;
+  imageUrl: string | null;
+  usedIngredients: UsedIngredient[];
+  completedAt: string;
+  createdAt: string;
+}
+
+export interface FrequentIngredient {
+  name: string;
+  count: number;
+}
+
+export interface FavoriteRecipe {
+  recipeId: number;
+  recipeName: string;
+  cookingCount: number;
+}
+
+export interface CookingRecordsResponse {
+  recentRecords: CookingRecord[];
+  frequentIngredients: FrequentIngredient[];
+  favoriteRecipes: FavoriteRecipe[];
+  monthlyStats: {
+    cookingCount: number;
+  };
+}
+
+// 요리 기록 생성
+export const createCookingRecord = async (data: {
+  recipeId: number;
+  recipeName: string;
+  usedIngredients: UsedIngredient[];
+  imageUrl?: string;
+}): Promise<CookingRecord> => {
+  const response = await fetch("/api/cooking-records", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData?.error || "요리 기록 생성에 실패했습니다.");
+  }
+
+  const result = await response.json();
+  
+  return {
+    ...result,
+    usedIngredients: typeof result.usedIngredients === 'string' 
+      ? JSON.parse(result.usedIngredients)
+      : result.usedIngredients
+  };
+};
+
+// 요리 기록 조회
+export const getCookingRecords = async (limit?: number): Promise<CookingRecordsResponse> => {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "";
+  const url = new URL(`${baseUrl}/api/cooking-records`);
+  
+  if (limit) {
+    url.searchParams.append("limit", limit.toString());
+  }
+
+  const response = await fetch(url.toString());
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData?.error || "요리 기록을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+};
+
+// 특정 재료 사용 기록 조회
+export const getIngredientUsageHistory = async (ingredientName: string) => {
+  const records = await getCookingRecords();
+  
+  return records.recentRecords.filter(record =>
+    record.usedIngredients.some(ingredient => 
+      ingredient.name.toLowerCase().includes(ingredientName.toLowerCase())
+    )
+  );
+};
+
+// 레시피별 요리 기록 조회
+export const getRecipeCookingHistory = async (recipeId: number) => {
+  const records = await getCookingRecords();
+  
+  return records.recentRecords.filter(record => record.recipeId === recipeId);
+};


### PR DESCRIPTION
## Jira Ticket Number
TF-73

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] 기능 개발
- [x] UI 

## 요약
- 요리완성 기록에 따라 다른 UI 제공
- 요리 완성 기록 저장 기능 구현 및 내 기록 페이지 실데이터 연동
- 요리 완성 모달에서 요리 기록을 DB에 저장
- 이번 달 통계, 자주 사용한 재료 실제 데이터 통계 제공

## 상세 내용
- 이번 달 통계: 월별 요리 완성 횟수 추적
- 자주 사용한 재료: 실제 사용 데이터 기반 상위 5개 재료 표시
- 즐겨찾는 레시피: 완성 빈도 기준 레시피 순위 제공

요리 기록이 없는 경우 | 요리 기록이 있는 경우
-- | --
<img width="600" alt="요리 기록 있음" src="https://github.com/user-attachments/assets/b6f06c81-a6ab-4253-9cb1-ea9903b90ff0" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/9c61c1b8-4aec-4bc4-9cd7-f25a77ec0416" />
빈 상태 UI 및 안내 메시지 표시|실제 데이터 기반 통계 및 기록 표시 

</pre>
